### PR TITLE
Fix/prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
 	"semi": true,
 	"singleQuote": true,
 	"tabWidth": 2,
-	"useTabs": true
+	"useTabs": true,
+	"endOfLine": "auto"
 }


### PR DESCRIPTION
맥, 윈도우 OS 차이로 발생하는 오류 수정

줄넘김시 prettier 는 LF 방식을 요구하는데 윈도우는 CRLF 방식으로 작동하기 때문에 발생하는 오류로
"endOfLine": "auto" 추가로 해결.